### PR TITLE
remove neon dependency for building and target android 28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,27 @@
 buildscript {
     repositories {
         jcenter()
+        google()
+
     }
 
     dependencies {
-        classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.0'
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:3.4.2'
     }
 }
 
-repositories {
-    jcenter()
+allprojects {
+
+    buildscript {
+        repositories {
+            jcenter()
+            google()
+        }
+    }
+
+    repositories {
+        jcenter()
+        google()
+    }
+
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Feb 07 20:58:36 PST 2015
+#Mon Jul 29 11:01:04 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/pngquant-android/build.gradle
+++ b/pngquant-android/build.gradle
@@ -1,9 +1,8 @@
-apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7

--- a/pngquant-android/src/main/jni/Application.mk
+++ b/pngquant-android/src/main/jni/Application.mk
@@ -1,3 +1,4 @@
-APP_ABI      := armeabi-v7a
+APP_ABI      := armeabi-v7a arm64-v8a x86
 APP_STL      := system
 APP_PLATFORM := android-8
+APP_CFLAGS += -DPNG_ARM_NEON_OPT=0

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -1,9 +1,8 @@
-apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
@@ -13,9 +12,9 @@ android {
     defaultConfig {
         applicationId "com.nicdahlquist.pngquant"
         minSdkVersion 18
-        targetSdkVersion 21
-        versionCode 1
-        versionName "1.0"
+        targetSdkVersion 28
+        versionCode 2
+        versionName "1.1"
     }
 
     buildTypes {
@@ -27,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile(project(':pngquant-android'))
+    implementation(project(':pngquant-android'))
 }


### PR DESCRIPTION
I needed to include the 64bit version of the underlying library for later google play store inclusion.

Compiling the base version of this gave me a linker error against libpng:
libpng undefined reference to png_init_filter_functions_neon

This commit adds the DPNG_ARM_NEON_OPT=0 CFLAG as well as the 64 bit arch target.

I also had to point at a later version of the Android Build Tools and gradle project...
